### PR TITLE
Fix audit findings: paste_object crash + bbox tightness + ruff (v0.2.2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
           python -m pip install -e ".[test]"
       - name: Check formatting
         run: black --check src tests dataset_tools
+      - name: Lint
+        run: ruff check src tests dataset_tools
       - name: Run tests
         run: pytest -q
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.2.2
+
+### Bug fixes
+- `CapAug.paste_object` no longer crashes when an `object_transforms` callable
+  crops or resizes the input. Previously the source dimensions were captured
+  before the transform ran, so the post-transform mask was sliced with stale
+  ROI bounds and OpenCV failed with a size-mismatch assertion. The transform
+  is now applied first, and shape-changing transforms that return mismatched
+  image and mask sizes raise a clear `ValueError`.
+- Returned bounding boxes are now tight against the visible (alpha > 0) region
+  of the pasted object rather than the source canvas. PNGs with transparent
+  padding (e.g. a 20×20 file containing a 10×10 visible object) used to yield
+  a box covering the full canvas; the box now matches the pixels that
+  actually changed in the destination. Behaviour is unchanged for fully
+  opaque sources.
+- Returned mask is sliced to the same tight region as the new bbox, so
+  multiclass aggregation and instance-mask blits stay aligned.
+
+### Dev / CI
+- `CONTRIBUTING.md` now tells contributors to also upgrade `setuptools` and
+  `wheel` when bootstrapping the dev venv. `python -m venv` seeds a pinned
+  old setuptools that `pip-audit` flags for known CVEs; the project build
+  itself uses `setuptools>=68` (see `pyproject.toml [build-system]`) so this
+  only affects the dev environment, but it removes the noise.
+- Added `ruff` lint to the project and CI (`tool.ruff` config in
+  `pyproject.toml`, `ruff check` step in `.github/workflows/test.yml`,
+  `ruff>=0.6` in the `[test]` and `[all]` extras). Auto-fixed 21 findings:
+  removed 2 genuinely unused imports
+  (`dataset_tools/cityscapes/filter_dataset.py:Path`,
+  `dataset_tools/vinbig/generate_dataset.py:os`), modernised
+  `super(Cls, self).__init__` and `class Foo(object)`, sorted imports, and
+  dropped redundant `# coding: utf-8` declarations.
+
 ## 0.2.1
 
 - Expose `cap_augmentation.__version__` (read from installed package metadata via `importlib.metadata`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,11 @@
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install --upgrade pip
+# Upgrade the seeded build tools — `python -m venv` ships an old setuptools
+# that has known CVEs (pip-audit will flag it). The package itself builds
+# with setuptools>=68 (see pyproject.toml [build-system]); this just brings
+# the dev venv's seeded versions in line.
+python -m pip install --upgrade pip setuptools wheel
 python -m pip install -e ".[test]"
 ```
 
@@ -17,11 +21,14 @@ Run the full test suite:
 pytest
 ```
 
-Check formatting:
+Check formatting and lint:
 
 ```bash
 black --check src tests dataset_tools
+ruff check src tests dataset_tools
 ```
+
+Both run in CI and must pass for merge.
 
 Run the optional Torchvision integration tests:
 

--- a/dataset_tools/cityscapes/config.py
+++ b/dataset_tools/cityscapes/config.py
@@ -1,5 +1,6 @@
-from easydict import EasyDict
 from pathlib import Path
+
+from easydict import EasyDict
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/dataset_tools/cityscapes/filter_dataset.py
+++ b/dataset_tools/cityscapes/filter_dataset.py
@@ -1,11 +1,10 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
-from scipy.io import loadmat
-from shutil import copyfile, rmtree
-from pathlib import Path
-import os
 import argparse
+import os
+from shutil import copyfile, rmtree
+
+from scipy.io import loadmat
 from tqdm import tqdm
 
 try:

--- a/dataset_tools/cityscapes/generate_dataset.py
+++ b/dataset_tools/cityscapes/generate_dataset.py
@@ -1,11 +1,11 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
+import argparse
 import os
+from shutil import rmtree
+
 import cv2
 import numpy as np
-from shutil import rmtree
-import argparse
 from tqdm import tqdm
 
 try:

--- a/dataset_tools/vinbig/config.py
+++ b/dataset_tools/vinbig/config.py
@@ -1,5 +1,6 @@
-from easydict import EasyDict
 from pathlib import Path
+
+from easydict import EasyDict
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/dataset_tools/vinbig/generate_analytics.py
+++ b/dataset_tools/vinbig/generate_analytics.py
@@ -1,11 +1,11 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
+from shutil import rmtree
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from shutil import rmtree
-import matplotlib.pyplot as plt
 
 try:
     from .config import data_generation as cfg
@@ -13,7 +13,7 @@ except ImportError:
     from config import data_generation as cfg
 
 
-class AverageMeter(object):
+class AverageMeter:
     """Computes and stores the average and current value"""
 
     def __init__(self):

--- a/dataset_tools/vinbig/generate_dataset.py
+++ b/dataset_tools/vinbig/generate_dataset.py
@@ -1,11 +1,10 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
-import os
+from shutil import rmtree
+
 import cv2
 import pandas as pd
 from tqdm import tqdm
-from shutil import rmtree
 
 try:
     from .config import data_generation as cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cap-augmentation"
-version = "0.2.1"
+version = "0.2.2"
 description = "Cut-and-paste augmentation for detection and segmentation datasets"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -74,6 +74,7 @@ test = [
     "matplotlib",
     "pandas",
     "pytest>=8",
+    "ruff>=0.6",
     "scikit-image>=0.19",
     "scipy",
     "tqdm",
@@ -91,6 +92,7 @@ all = [
     "easydict",
     "matplotlib",
     "pandas",
+    "ruff>=0.6",
     "scikit-image>=0.19",
     "scipy",
     "torch>=2",
@@ -113,3 +115,28 @@ pythonpath = ["src", "."]
 [tool.black]
 target-version = ["py39"]
 include = '\.py$'
+
+[tool.ruff]
+target-version = "py39"
+line-length = 88
+extend-exclude = ["examples"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # Pyflakes (unused imports, undefined names)
+    "W",   # pycodestyle warnings
+    "I",   # isort (import ordering)
+    "B",   # flake8-bugbear (likely bugs)
+    "UP",  # pyupgrade (modernization)
+]
+ignore = [
+    "E501",  # line too long — Black handles wrapping
+    "E741",  # ambiguous variable name — collides with conventional math/CV names
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Dataset scripts mix Python data definitions with imperative blocks at module
+# level; the upstream-author style differs from the library code and we don't
+# want to churn it in this refactor.
+"dataset_tools/**" = ["B007", "E402"]

--- a/src/cap_augmentation/__init__.py
+++ b/src/cap_augmentation/__init__.py
@@ -1,6 +1,7 @@
 """Cut-and-paste augmentation utilities."""
 
-from importlib.metadata import PackageNotFoundError, version as _version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
 
 from .cap_aug import CapAug, CapAugMulticlass, resize_keep_ar
 

--- a/src/cap_augmentation/bev/bev_transform.py
+++ b/src/cap_augmentation/bev/bev_transform.py
@@ -119,7 +119,7 @@ def get_BEV_H(camera_info=None, calib_yaml_path=None, pix_per_meter=None):
     return H, calib_matrices
 
 
-class BEV(object):
+class BEV:
     def __init__(self, camera_info=None, calib_yaml_path=None, pix_per_meter=None):
         if pix_per_meter is None:
             pix_per_meter = _DEFAULT_PIX_PER_METER

--- a/src/cap_augmentation/cap_aug.py
+++ b/src/cap_augmentation/cap_aug.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
 import random
@@ -66,7 +65,7 @@ def _with_class_column(coords, class_idx):
     return coords
 
 
-class CapAugMulticlass(object):
+class CapAugMulticlass:
     """
     cap_augs - list of cap augmentations for each class
     probabilities - list of probabilities for each augmentation
@@ -116,7 +115,7 @@ class CapAugMulticlass(object):
         return result_image, total_result_coords, result_sem_mask, total_instance_masks
 
 
-class CapAug(object):
+class CapAug:
     """
     source_images - list of image paths
     bev_transform - bird's eye view transformation
@@ -509,7 +508,24 @@ class CapAug(object):
         if random_v_flip and random.uniform(0, 1) > 0.5:
             image_src = cv2.flip(image_src, 0)
 
-        src_h, src_w = image_src.shape[:2]
+        mask_src = image_src[:, :, 3]
+        rgb_img = image_src[:, :, :3]
+
+        # Apply object-level transforms before reading dimensions: a transform
+        # may crop or resize the image/mask, so size-derived ROI bounds must be
+        # computed from the post-transform shapes.
+        if self.object_transforms is not None:
+            rgb_img, mask_src = _apply_image_mask_transform(
+                self.object_transforms, rgb_img, mask_src
+            )
+            if rgb_img.shape[:2] != mask_src.shape[:2]:
+                raise ValueError(
+                    "object_transforms must return image and mask with the same "
+                    f"height/width; got image {rgb_img.shape[:2]} and mask "
+                    f"{mask_src.shape[:2]}"
+                )
+
+        src_h, src_w = mask_src.shape[:2]
         dst_h, dst_w = image_dst.shape[:2]
         x_offset = int(round(x_coord - src_w / 2))
         y_offset = int(round(y_coord - src_h))
@@ -521,14 +537,6 @@ class CapAug(object):
 
         y1_m, y2_m = y1 - y_offset, y2 - y_offset
         x1_m, x2_m = x1 - x_offset, x2 - x_offset
-
-        mask_src = image_src[:, :, 3]
-        rgb_img = image_src[:, :, :3]
-
-        if self.object_transforms is not None:
-            rgb_img, mask_src = _apply_image_mask_transform(
-                self.object_transforms, rgb_img, mask_src
-            )
 
         src_roi = rgb_img[y1_m:y2_m, x1_m:x2_m]
         dst_roi = image_dst[y1:y2, x1:x2]
@@ -546,4 +554,17 @@ class CapAug(object):
             out_img = cv2.add(img1_bg, img2_fg)
 
         image_dst[y1:y2, x1:x2] = out_img
-        return image_dst, [x1, y1, x2, y2], mask_roi
+
+        # Tighten the returned bbox to the visible (alpha>0) pixels of the
+        # pasted ROI translated into destination coords, so PNGs with
+        # transparent padding don't yield boxes covering empty canvas. The
+        # mask is sliced to the same tight region so callers can blit it
+        # into instance/semantic masks at the bbox coordinates.
+        ys, xs = np.where(mask_roi > 0)
+        if ys.size == 0:
+            return image_dst, [], mask_roi
+        y_min, y_max = int(ys.min()), int(ys.max()) + 1
+        x_min, x_max = int(xs.min()), int(xs.max()) + 1
+        tight_box = [x1 + x_min, y1 + y_min, x1 + x_max, y1 + y_max]
+        tight_mask = mask_roi[y_min:y_max, x_min:x_max]
+        return image_dst, tight_box, tight_mask

--- a/src/cap_augmentation/utils.py
+++ b/src/cap_augmentation/utils.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 __author__ = "RocketFlash: https://github.com/RocketFlash"
 
 import cv2

--- a/src/cap_augmentation/wrappers/albu.py
+++ b/src/cap_augmentation/wrappers/albu.py
@@ -29,7 +29,7 @@ class CapAlbumentations(A.DualTransform):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        super(CapAlbumentations, self).__init__(p=1.0 if always_apply else p)
+        super().__init__(p=1.0 if always_apply else p)
 
         self.cap_aug = CapAug(**kwargs)
         self.cap_image = None

--- a/tests/test_cap_aug.py
+++ b/tests/test_cap_aug.py
@@ -1,13 +1,12 @@
+import albumentations as A
 import cv2
 import numpy as np
 import pytest
 
-import albumentations as A
-
 from cap_augmentation import (
+    CapAlbumentations,
     CapAug,
     CapAugMulticlass,
-    CapAlbumentations,
     ImageMaskTransform,
     resize_keep_ar,
 )
@@ -197,6 +196,97 @@ def test_rgb_grayscale_source_loads_as_four_channels(tmp_path):
 
     assert selected.shape == (4, 4, 4)
     assert selected[0, 0].tolist() == [17, 17, 17, 255]
+
+
+def test_shape_changing_object_transform_does_not_crash(
+    destination_image, make_source_image
+):
+    """Regression: object_transforms that crop/resize used to crash because
+    src_h/src_w were captured before the transform ran but the mask ROI was
+    sliced after it.
+    """
+    source = make_source_image()  # 20x10 alpha PNG
+
+    def crop_to_half(image, mask):
+        h, w = image.shape[:2]
+        return image[: h // 2, : w // 2], mask[: h // 2, : w // 2]
+
+    aug = CapAug(
+        [source],
+        n_objects_range=[1, 1],
+        h_range=[20, 21],
+        x_range=[50, 51],
+        y_range=[80, 81],
+        random_h_flip=False,
+        random_v_flip=False,
+        object_transforms=ImageMaskTransform(crop_to_half),
+    )
+
+    result, boxes, semantic_mask, _ = aug(destination_image)
+
+    assert boxes.shape == (1, 4)
+    box = boxes[0].tolist()
+    # Object cropped to 10x5; placement uses post-transform dims so the box
+    # is small and the result image was modified inside that box.
+    assert box[2] - box[0] == 5 and box[3] - box[1] == 10
+    assert semantic_mask.sum() == 50
+    assert not np.array_equal(result[box[1] : box[3], box[0] : box[2]], 0)
+
+
+def test_object_transform_with_mismatched_shapes_raises(
+    destination_image, make_source_image
+):
+    """A transform that returns image and mask with different H/W should fail
+    with a clear error instead of a downstream OpenCV assertion.
+    """
+    source = make_source_image()
+
+    def bad_transform(image, mask):
+        return image[:10, :5], mask  # image shrunk, mask untouched -> mismatch
+
+    aug = CapAug(
+        [source],
+        n_objects_range=[1, 1],
+        h_range=[20, 21],
+        x_range=[50, 51],
+        y_range=[80, 81],
+        random_h_flip=False,
+        object_transforms=ImageMaskTransform(bad_transform),
+    )
+
+    with pytest.raises(ValueError, match="same height/width"):
+        aug(destination_image)
+
+
+def test_alpha_padded_source_yields_tight_bbox(tmp_path, destination_image):
+    """Regression: a PNG with transparent padding around the visible object
+    used to return a bbox covering the full canvas. The bbox must match the
+    visible alpha region instead.
+    """
+    # 20x20 canvas with a 10x10 fully opaque region centered (5..15, 5..15).
+    src = np.zeros((20, 20, 4), dtype=np.uint8)
+    src[5:15, 5:15, :3] = (10, 20, 200)
+    src[5:15, 5:15, 3] = 255
+    src_path = tmp_path / "padded.png"
+    cv2.imwrite(str(src_path), src)
+
+    aug = CapAug(
+        [src_path],
+        n_objects_range=[1, 1],
+        h_range=[20, 21],  # canvas height
+        x_range=[50, 51],
+        y_range=[80, 81],
+        random_h_flip=False,
+        random_v_flip=False,
+    )
+    _, boxes, semantic_mask, _ = aug(destination_image)
+
+    # Old (canvas-based) box would be [40, 60, 60, 80] (20x20 canvas).
+    # Tight (alpha-based) box must match where the visible 10x10 pixels
+    # actually landed in dst: canvas top-left = (40, 60), inner alpha
+    # offset (5, 5), so [45, 65, 55, 75].
+    assert boxes.tolist() == [[45, 65, 55, 75]]
+    assert semantic_mask.sum() == 100  # exactly the 10x10 visible region
 
 
 def test_missing_source_image_raises(destination_image, tmp_path):


### PR DESCRIPTION
Addresses all four findings from the reviewer's audit:

## Bug fixes (find #1 + #2 — high priority)

### #1 paste_object crashes with shape-changing object_transforms

`src_h/src_w` were captured **before** `object_transforms` ran, then the post-transform mask was sliced with stale ROI bounds → OpenCV blew up with a size-mismatch assertion if the transform cropped or resized.

**Fix**: apply `object_transforms` first; derive `src_h/src_w` from the post-transform shape. Mismatched image/mask sizes from the transform now raise a clear `ValueError` instead of dying inside `cv2`.

### #2 Bounding boxes include transparent padding

Returned boxes used the source canvas dimensions, so a 20×20 PNG with a 10×10 visible object returned `[40, 60, 60, 80]` while the visible pixels only occupied `[45, 65, 55, 75]`.

**Fix**: derive the returned bbox from `mask_roi > 0` (the alpha-positive region of the pasted ROI), translated into destination coords. The returned mask is sliced to the same tight region so multiclass aggregation and instance-mask blits stay aligned. Pixel placement in the output image is unchanged. Fully opaque sources are unaffected (existing tests pass without modification).

Verified with the reviewer's exact reproduction: 20×20 PNG with 10×10 visible region now returns `[[45, 65, 55, 75]]` and mask = 100 pixels.

## Regression tests

Three new tests in `tests/test_cap_aug.py`:
- `test_shape_changing_object_transform_does_not_crash` — bug #1
- `test_object_transform_with_mismatched_shapes_raises` — defensive companion
- `test_alpha_padded_source_yields_tight_bbox` — bug #2

`pytest`: 31 passed (28 pre-existing + 3 new). `black --check` and `ruff check` both clean.

## Dev / CI (finds #3 + #4)

### #3 CONTRIBUTING.md: also upgrade `setuptools` and `wheel`

`python -m venv` seeds a pinned old setuptools that `pip-audit` flags for 5 known CVEs. The package itself builds with `setuptools>=68` (declared in `pyproject.toml [build-system]`), so this is a dev-environment hygiene issue, not a runtime one — but updating the bootstrap removes the noise.

### #4 Add ruff lint

- `tool.ruff` config in `pyproject.toml`: target `py39`, line length 88 (matches Black), enabled rule families E/F/W/I/B/UP, ignored E501 (line length — let Black own that) and E741 (ambiguous names — collides with valid CV conventions).
- `ruff>=0.6` added to the `[test]` and `[all]` extras.
- `ruff check` step added to `.github/workflows/test.yml` between Black and pytest.
- Auto-fixed 21 existing findings, including 2 genuine unused imports the reviewer flagged: `Path` in `dataset_tools/cityscapes/filter_dataset.py`, `os` in `dataset_tools/vinbig/generate_dataset.py`.

## Release

`pyproject.toml` version: `0.2.1` → `0.2.2`. CHANGELOG entry added. After merge I'll publish via twine (trusted publishing isn't set up yet — see PR #9 history) and tag `v0.2.2`.

## Test plan

- [ ] CI passes (black, ruff, pytest on Python 3.9 / 3.11 / 3.12 + torchvision job)
- [ ] Reviewer re-runs `pip-audit` on a fresh dev venv — should be clean
- [ ] Reviewer re-runs their bug #2 repro with the published 0.2.2 wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)