### PR TITLE
Release 0.5.0: version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ version with the leading `v` stripped. Keep-a-Changelog style headers
 like `## [0.3.0] - 2026-05-17` will silently produce empty notes.
 -->
 
+## 0.5.0
+
+### New features
+- `seamless_blend(foreground_path, background_path, center_x, center_y,
+  output_path, mode="normal")`: Poisson image compositing via
+  `cv2.seamlessClone`. Reads an RGBA foreground, reuses its alpha as the
+  clone mask, auto-scales the foreground to fit the destination, and
+  supports `"normal"` / `"mixed"` / `"monochrome"` clone modes. Exported
+  from the top-level package. Opt-in — `CapAug` continues to default to
+  plain alpha compositing.
+- `BEV.from_image_shape(shape, ...)`: construct a BEV transform without a
+  calibration YAML. Synthesizes intrinsics from image dimensions
+  (`fx = fy = max(W, H)`, principal point at center). Paired with the new
+  public helper `intrinsics_from_image_shape(height, width)`. `BEV()` with
+  no arguments still loads the packaged AXIS default — unchanged.
+- `BEV(calib_matrices=...)`: pass a pre-built `{"camera_matrix": K}` dict
+  to bypass YAML loading.
+
+### Tooling
+- `dataset_tools/cityscapes/download_dataset.py`: stdlib-only Cityscapes
+  downloader using `CITYSCAPES_USERNAME` / `CITYSCAPES_PASSWORD` env vars.
+  `run.sh` gains a `--download` step and auto-sources a gitignored
+  repo-root `.env`; `.env.example` ships as a template. Repo-only tooling,
+  not part of the installed wheel.
+
+### Docs
+- README: `seamless_blend` listed in the Public API; new "Without your own
+  calibration" section covering `BEV.from_image_shape` and the
+  no-perspective `bev_transform=None` fallback.
+
 ## 0.4.1
 
 ### New features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cap-augmentation"
-version = "0.4.1"
+version = "0.5.0"
 description = "Cut-and-paste augmentation for detection and segmentation datasets"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` to `0.5.0` and adds the `## 0.5.0` CHANGELOG
section. This is the version-bump half of the release that was missing
from the squash merge of #12 — all the feature code from #12 is already
on `main` at version `0.4.1`; this PR just raises the version so a
`v0.5.0` tag publishes a real release rather than no-op'ing on the
already-published `0.4.1`.

`0.5.0` (minor) because #12 was purely additive: `seamless_blend`,
`BEV.from_image_shape` / `intrinsics_from_image_shape`, and the
repo-only Cityscapes downloader. No breaking changes.

## After merge

Tag `v0.5.0` on `main` → triggers `publish.yml` → PyPI. The CHANGELOG
header is plain `## 0.5.0` so the publish workflow's release-notes
extractor picks it up.

## Test plan

- [x] Diff is exactly `pyproject.toml` + `CHANGELOG.md`
- [x] Version reads `0.5.0`; CHANGELOG `## 0.5.0` is the top entry
- [x] CI (pytest matrix + black + ruff) runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)